### PR TITLE
adds an option to disable the setting of legacy headers

### DIFF
--- a/classes/SecurityHeaders.php
+++ b/classes/SecurityHeaders.php
@@ -125,6 +125,7 @@ class SecurityHeaders
             'headers' => option('bnomei.securityheaders.headers'),
             'loader' => option('bnomei.securityheaders.loader'),
             'setter' => option('bnomei.securityheaders.setter'),
+            'legacy' => option('bnomei.securityheaders.legacy'),
         ], $options);
 
         foreach ($this->options as $key => $call) {
@@ -249,8 +250,8 @@ class SecurityHeaders
             header(strval($key).': '.strval($value));
         }
 
-        return $this->cspBuilder->sendCSPHeader();
-    }
+        return $this->cspBuilder->sendCSPHeader($this->option('legacy'));
+	}
 
     public function saveApache(string $filepath): bool
     {

--- a/index.php
+++ b/index.php
@@ -7,6 +7,7 @@ use Kirby\Http\Url;
 Kirby::plugin('bnomei/securityheaders', [
     'options' => [
         'enabled' => null, // null => auto-detection: disable in debug-mode, panel and api
+        'legacy' => true, // false -> disable deprecated legacy header generation
         'seed' => function () {
             return Url::stripPath(site()->url());
         },

--- a/readme.md
+++ b/readme.md
@@ -142,15 +142,25 @@ disabled if one the following conditions apply:
 > [!WARNING]
 > By default, CSP headers are never sent for any Kirby Panel, API and Media routes.
 
+## Legacy headers
+
+It is known that having both Content-Security-Policy and X-Content-Security-Policy or X-Webkit-CSP causes unexpected behaviors on certain versions of browsers. Please avoid using deprecated X-* headers [[1]](https://content-security-policy.com/).
+[[2]](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html#warning)
+
+It is also recommended that you use Content-Security-Policy instead of XSS filtering.
+[[3]](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)
+[[4]](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection)
+
 ## Settings
 
-| bnomei.securityheaders. | Default           | Description                                               |            
-|-------------------------|-------------------|-----------------------------------------------------------|
-| enabled                 | `null/true/false` | will set headers                                          |
-| seed                    | `callback`        | returns a unique seed for frontend nonces on every request |
-| headers                 | `callback`        | array of sensible default values                          |
-| loader                  | `callback`        | returning filepath or array                               |
-| setter                  | `callback`        | instance which allows customizing the CSPBuilder          |
+| bnomei.securityheaders. | Default           | Description                                                     |            
+|-------------------------|-------------------|-----------------------------------------------------------------|
+| enabled                 | `null/true/false` | will set headers                                                |
+| legacy                  | `true`            | disables setting deprecated legacy headers (see Legacy headers) |
+| seed                    | `callback`        | returns a unique seed for frontend nonces on every request      |
+| headers                 | `callback`        | array of sensible default values                                |
+| loader                  | `callback`        | returning filepath or array                                     |
+| setter                  | `callback`        | instance which allows customizing the CSPBuilder                |
 
 ## Dependencies
 


### PR DESCRIPTION
As per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection) and [OWASP](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#x-xss-protection) it is recommended to not use deprecated security headers. 
This PR enables passing that parameter to [paragonie/csp-builder](https://github.com/paragonie/csp-builder)